### PR TITLE
Point badge at master builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ObjectState
 
-[![Build Status](http://img.shields.io/travis/urbanairship/objectstate.svg?style=flat)](https://travis-ci.org/urbanairship/objectstate)
+[![Build Status](http://img.shields.io/travis/urbanairship/objectstate/master.svg?style=flat)](https://travis-ci.org/urbanairship/objectstate)
 [![npm install](http://img.shields.io/npm/dm/objectstate.svg?style=flat)](https://www.npmjs.org/package/objectstate)
 
 `objectstate` exports a function that constructs a stream. The stream is


### PR DESCRIPTION
previously this was just pointing at whatever the most recent build was, even for just test branches. this will provide a more accurate representation of the build status.
