### PR TITLE
Use `is-equal` for deep-equality matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 var through = require('through')
 
-var deepequal = require('deep-equal')
-  , prop = require('deep-property')
+var prop = require('deep-property')
+  , equal = require('is-equal')
 
 module.exports = objectState
 
@@ -138,8 +138,4 @@ function objectState(_initial) {
 
 function deepcopy(obj) {
   return obj ? JSON.parse(JSON.stringify(obj)) : obj
-}
-
-function equal(x, y) {
-  return deepequal(x, y, {strict: true})
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test": "node ./test.js"
   },
   "dependencies": {
-    "deep-equal": "^0.2.1",
     "deep-property": "^1.1.0",
+    "is-equal": "^1.2.0",
     "through": "^2.3.6"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -379,6 +379,16 @@ test('can remove an attr via `.remove()`', function(assert) {
   os.remove('no.sure')
 })
 
+test('correctly sets values with understanding of type', function(assert) {
+  assert.plan(1)
+
+  var os = objectState({cats: true})
+
+  os.set('cats', [])
+
+  assert.notEqual(true, os.get('cats'))
+})
+
 function noop() {
   // no-op
 }


### PR DESCRIPTION
[deep-equal](http://npm.im/deep-equal) has a bug that prevents it from working correctly in-browser. I have a [PR opened against it](https://github.com/substack/node-deep-equal/pull/17) that has yet to receive any response.

I added a test that reliably fails via `browserify ./test | testling -u` in chrome using the current published version, and passes using this changeset.

My plan is to bump by patch version if this is accepted.