### PR TITLE
Use deep-equal for deep equality checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 var through = require('through')
 
-var prop = require('deep-property')
-  , equal = require('is-equal')
+var deepequal = require('deep-equal')
+  , prop = require('deep-property')
 
 module.exports = objectState
 
@@ -138,4 +138,8 @@ function objectState(_initial) {
 
 function deepcopy(obj) {
   return obj ? JSON.parse(JSON.stringify(obj)) : obj
+}
+
+function equal(x, y) {
+  return deepequal(x, y, {strict: true})
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test": "node ./test.js"
   },
   "dependencies": {
+    "deep-equal": "^1.0.0",
     "deep-property": "^1.1.0",
-    "is-equal": "^1.2.0",
     "through": "^2.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
[The reason for swapping out deep-equal for is-equal](https://github.com/urbanairship/objectstate/pull/17) has [since been nullified](https://github.com/substack/node-deep-equal/pull/17), and deep-equal seems to perform much better (about twice as fast according to my benchmarks).