### PR TITLE
drop writes of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function objectState(_initial) {
   return stream
 
   function write(data) {
-    if(equal(state, data)) {
+    if(equal(state, data) || typeof data === 'undefined') {
       return
     }
 

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function objectState(_initial) {
 }
 
 function deepcopy(obj) {
-  return obj ? JSON.parse(JSON.stringify(obj)) : obj
+  return typeof obj !== 'undefined' ? JSON.parse(JSON.stringify(obj)) : void 0
 }
 
 function equal(x, y) {

--- a/test.js
+++ b/test.js
@@ -389,6 +389,20 @@ test('correctly sets values with understanding of type', function(assert) {
   assert.notEqual(true, os.get('cats'))
 })
 
+test('drops writes of `undefined`', function(assert) {
+  assert.plan(1)
+
+  var os = objectState({cats: true})
+
+  os.on('data', function() {
+    assert.fail()
+  })
+
+  os.write(undefined)
+
+  assert.deepEqual(os.state(), {cats: true})
+})
+
 function noop() {
   // no-op
 }


### PR DESCRIPTION
previously, writing `undefined` to objectstate would actually set its internal state object to `undefined` which leads to interesting fun things.

because i cannot imagine a scenario where that is desirable, the decision has been made to drop `undefined` writes. this should result in a patch version upgrade.